### PR TITLE
[Fix] auth api 관련 수정

### DIFF
--- a/src/apis/auth.js
+++ b/src/apis/auth.js
@@ -3,34 +3,34 @@ import { axiosInstance } from './axios';
 // 아이디 유효성(중복 검사)
 const validatePhone = async (phoneNumber) => {
   const res = await axiosInstance.post('/api/v1/auth/validate/phone', { phoneNumber });
-  return res.data;
+  return res.data.result;
 };
 
 const validateEmail = async (email) => {
   const res = await axiosInstance.post('/api/v1/auth/validate/email', { email });
-  return res.data;
+  return res.data.result;
 };
 
 // 회원가입
 const signupPhone = async (phoneNumber, password) => {
   const res = await axiosInstance.post('/api/v1/auth/signup/phone', { phoneNumber, password });
-  return res.data;
+  return res.data.result;
 };
 
 const signupEmail = async (email, password) => {
   const res = await axiosInstance.post('/api/v1/auth/signup/email', { email, password });
-  return res.data;
+  return res.data.result;
 };
 
 // 로그인
 const loginPhone = async (phoneNumber, password) => {
   const res = await axiosInstance.post('/api/v1/auth/login/phone', { phoneNumber, password });
-  return res.data;
+  return res.data.result;
 };
 
 const loginEmail = async (email, password) => {
   const res = await axiosInstance.post('/api/v1/auth/login/email', { email, password });
-  return res.data;
+  return res.data.result;
 };
 
 // 카카오 로그인
@@ -38,29 +38,26 @@ const kakaoLogin = async (code) => {
   const res = await axiosInstance.post('/api/v1/auth/kakao', {
     code,
   });
-  console.log(res);
-  return res.data;
+  return res.data.result;
 };
 
 // 로그아웃
 const logout = async (refreshToken) => {
   const res = await axiosInstance.post('/api/v1/auth/logout', { refreshToken });
-  return res.data;
+  return res.data.result;
 };
 
-// 엑세스 토큰 재발급
-const refreshAccessToken = async (refreshToken) => {
-  const res = await axiosInstance.post('/api/v1/auth/refresh', { refreshToken });
-  return res.data;
-};
+// // 엑세스 토큰 재발급 -> 자동 재발급 로직
+// const refreshAccessToken = async (refreshToken) => {
+//   const res = await axiosInstance.post('/api/v1/auth/refresh', { refreshToken });
+//   return res.data.result;
+// };
 
 //
 const getMe = async () => {
   const res = await axiosInstance.get('/api/v1/auth/me');
-  return res.data;
+  return res.data.result;
 };
-
-
 
 export {
   validatePhone,
@@ -70,7 +67,6 @@ export {
   loginPhone,
   loginEmail,
   logout,
-  refreshAccessToken,
   kakaoLogin,
   getMe,
 };

--- a/src/apis/axios.js
+++ b/src/apis/axios.js
@@ -1,6 +1,11 @@
 import axios from 'axios';
 import { useAuthStore } from '../stores/useAuthStore';
 
+const gotoAuth = () => {
+  // 뒤로가기 시 보호 페이지로 되돌아오지 않도록 replace 사용
+  window.location.replace('/auth');
+};
+
 export const axiosInstance = axios.create({
   baseURL: import.meta.env.VITE_API_URL, // 백엔드 URL .env로
   headers: {
@@ -20,13 +25,69 @@ axiosInstance.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+// 재발급 중복을 막기 위한 변수
+let isRefreshing = false;
+// 재발급 처리 프로미스 객체
+let refreshPromise = null;
+
 // 응답 인터셉터
 axiosInstance.interceptors.response.use(
   (response) => response,
-  (error) => {
-    if (error.response?.status === 401) {
-      console.log('401: 토큰 만료 또는 인증 오류');
-      // 여기서 토큰 재발급 로직
+  async (error) => {
+    const status = error.response?.status;
+    // 백엔드 토큰 만료 상태 코드가 완전하지 않아 임시로...
+    if ([401, 403].includes(status)) {
+      const originalRequest = error.config;
+
+      // 무한 루프 방지 이미 재발급 처리를 한 요청 -> 로그아웃
+      // 즉, 토큰 문제가 아닌 다른 오류에 의한 에러 -> 백엔드 상태 코드 정상화 이후에는 크게 필요 x
+      if (originalRequest._retry) {
+        useAuthStore.getState().clearTokens();
+        gotoAuth();
+        return Promise.reject(error);
+      }
+
+      
+      const { refreshToken } = useAuthStore.getState();
+      // 리프레시 토큰 없을시 -> 에러 -> 로그아웃 처리
+      if (!refreshToken) {
+        return Promise.reject(error);
+      }
+
+      try {
+        // 재발급 중일 경우에는 처리 x
+        // api 두개 동시 요청 -> 재발급 2번 상황 방지
+        if (!isRefreshing) {
+          isRefreshing = true;
+          // 재발급 용 객체
+          refreshPromise = axios
+            // 재발급
+            .post(`${import.meta.env.VITE_API_URL}/api/v1/auth/refresh`, { refreshToken })
+            .then((res) => {
+              const { accessToken: newAccessToken, refreshToken: newRefreshToken } = res.data?.result || {};
+              // 재발급 실패시 에러 -> catch해서 로그아웃
+              if (!newAccessToken || !newRefreshToken) throw new Error('Invalid refresh response');
+              useAuthStore.getState().setTokens(newAccessToken, newRefreshToken);
+              return newAccessToken;
+            })
+            .finally(() => {
+              isRefreshing = false;
+            });
+        }
+
+        const newAccessToken = await refreshPromise;
+        // 성공 실패 여부에 관계없이 원래 요청은 이 함수가 다시 인터셉트 해도 pass
+        originalRequest._retry = true;
+        originalRequest.headers = originalRequest.headers || {};
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        // 원래 요청 재발급된 토큰으로 요청
+        return axiosInstance(originalRequest);
+      } catch (refreshError) {
+        // 재발급 실패시 로그아웃 처리
+        useAuthStore.getState().clearTokens();
+        gotoAuth();
+        return Promise.reject(refreshError);
+      }
     }
     return Promise.reject(error);
   }

--- a/src/stores/useAuthStore.js
+++ b/src/stores/useAuthStore.js
@@ -1,23 +1,31 @@
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 
-export const useAuthStore = create((set) => ({
-  isLoggedIn: false,
-  accessToken: null,
-  refreshToken: null,
-
-  setTokens: (accessToken, refreshToken) => {
-    set({
-      isLoggedIn: true,
-      accessToken,
-      refreshToken,
-    });
-  },
-
-  clearAuth: () => {
-    set({
+export const useAuthStore = create(
+  persist(
+    (set) => ({
       isLoggedIn: false,
       accessToken: null,
       refreshToken: null,
-    });
-  },
-}));
+
+      setTokens: (accessToken, refreshToken) => {
+        set({
+          isLoggedIn: true,
+          accessToken,
+          refreshToken,
+        });
+      },
+
+      clearAuth: () => {
+        set({
+          isLoggedIn: false,
+          accessToken: null,
+          refreshToken: null,
+        });
+      },
+    }),
+    {
+      name: 'auth-storage', // key in localStorage
+    }
+  )
+);


### PR DESCRIPTION
- 인증 응답 스펙을 result 래핑으로 통일
- 액세스 토큰 자동 첨부(요청 인터셉터)
- 401 시 단일 재발급 흐름(중복 방지, 원요청 자동 재시도)
- Zustand persist로 새로고침 후에도 로그인 유지
- 재발급 실패/루프 감지 시 /auth로 강제 이동(하드 리다이렉트)

## useAuthStore

- setTokens(accessToken, refreshToken)
- clearAuth() (로그아웃)
- persist(name: 'auth-storage') 로 localStorage 저장

## axiosInstance

- 요청 시 Authorization: Bearer <accessToken> 자동 주입
- 응답 401에서만 재발급 시도(중복 방지: isRefreshing, refreshPromise)
- 재발급 성공 시 원요청 재시도, 실패 시 토큰 삭제 후 /auth 이동