### PR TITLE
[FEAT/FIX] chat api

### DIFF
--- a/src/apis/chatApis.js
+++ b/src/apis/chatApis.js
@@ -1,0 +1,143 @@
+import { axiosInstance } from './axios';
+import { useAuthStore } from '../stores/useAuthStore';
+
+// 채팅 메세지 전송 -> messageId를 반환
+const postChatApi = async (message) => {
+  const res = await axiosInstance.post('/api/v1/chat/messages', { message });
+  return res.data.result;
+};
+
+// 메시지에 대한 챗봇의 답변을 SSE로 스트리밍
+const getChatApi = (messageId, { onOpen, onMessage, onError, onDone } = {}) => {
+  // sse에 토큰 달려면 fetch 사용해야 하므로 axios x
+  const url = import.meta.env.VITE_API_URL + `/api/v1/chat/sse/messages/${encodeURIComponent(messageId)}`;
+  //  SSE 연결을 중단 컨트롤러
+  const controller = new AbortController();
+
+  (async () => {
+    try {
+      // 스토어에서 엑세스 토큰 받아옴
+      const { accessToken } = useAuthStore.getState();
+      const token = accessToken;
+
+      // 토큰으로 sse요청 보냄
+      const res = await fetch(url, {
+        method: 'GET',
+        headers: {
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          Accept: 'text/event-stream',
+          'Cache-Control': 'no-cache',
+        },
+        mode: 'cors',
+        cache: 'no-store',
+        signal: controller.signal,
+      });
+
+      // 서버 응답 x 
+      if (!res.ok || !res.body) {
+        throw new Error(`SSE connection failed: HTTP ${res.status}`);
+      }
+
+      // SSE 연결이 성공 -> 콜백 함수 실행(sse 연결 이후 실행 로직)
+      onOpen && onOpen();
+
+      // sse 파서
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder('utf-8');
+      let buffer = '';
+
+      // 응답을 받아 청크로 처리
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Split SSE events by blank line (\n\n or \r\n\r\n)
+        let parts = buffer.split(/\r?\n\r?\n/);
+        buffer = parts.pop() ?? '';
+
+        for (const part of parts) {
+          const lines = part.split(/\r?\n/);
+          let eventName = 'message'; // default per SSE spec
+          let dataLines = [];
+
+          for (const line of lines) {
+            if (!line) continue;
+            if (line.startsWith(':')) continue; // comment/keep-alive
+            if (line.startsWith('event:')) {
+              eventName = line.slice(6).trim();
+              continue;
+            }
+            if (line.startsWith('data:')) {
+              dataLines.push(line.slice(5));
+              continue;
+            }
+          }
+
+          const payloadRaw = dataLines.join('\n');
+
+          // 이벤트로 수신 받은 메세지 콜백 함수 onMessage로 로직 실행
+          if (eventName === 'message') {
+            const txt = payloadRaw;
+            // onMessage로 로직 실행
+            if (onMessage) {
+              if (txt && (txt.startsWith('{') || txt.startsWith('['))) {
+                try { onMessage(JSON.parse(txt)); } catch { onMessage(txt); }
+              } else {
+                onMessage(txt);
+              }
+            }
+            continue;
+          }
+
+          // done 이벤트 수신시 종료
+          if (eventName === 'done') {
+            onDone && onDone();
+            controller.abort();
+            return;
+          }
+        }
+      }
+      // 종료 이후 done이 안 올 경우 종료
+      if (!controller.signal.aborted) {
+        try { onDone && onDone(); } catch (e) {console.log(e)}
+      }
+    } catch (err) {
+      if (controller.signal.aborted) return; // closed intentionally
+      onError && onError(err);
+    }
+  })();
+
+  return {
+    close: () => controller.abort(),
+  };
+};
+
+// 사용자의 채팅 히스토리를 조회합니다 (페이지네이션 지원)
+const getChatHistoryApi = async (limit, beforeId) => {
+  const res = await axiosInstance.get('/api/v1/chat/history', {
+    params: {
+      ...(limit != null ? { limit } : {}),
+      ...(beforeId != null ? { beforeId } : {}),
+    },
+  });
+  return res.data.result;
+};
+// {
+//   "messages": [
+//     {
+//       "chatId": 0,
+//       "speaker": "string",
+//       "message": "string",
+//       "createdAt": "string",
+//       "showDate": true,
+//       "dateLabel": "string",
+//       "showTime": true,
+//       "timeLabel": "string"
+//     }
+//   ],
+//   "hasMore": true,
+//   "nextBeforeId": 0
+// }
+export { postChatApi, getChatApi, getChatHistoryApi };

--- a/src/components/chatbot/Chat.jsx
+++ b/src/components/chatbot/Chat.jsx
@@ -1,13 +1,13 @@
 import ChatAvatar from "../../assets/chatbot/chatAvatar.svg?react";
 
 export default function Chat({ role, message }) {
-  const isUser = role === 'user';
+  const isUser = role === 'USER';
 
   if (isUser) {
     return (
       <div className="w-full flex justify-end">
         <div className="max-w-3/4 bg-chat py-2 px-3 rounded-2xl rounded-br-[4px] ">
-          <span className="text-body-02-regular text-white ">{message}</span>
+          <span className="text-body-02-regular text-white whitespace-pre-wrap">{message}</span>
         </div>
       </div>
     );
@@ -20,7 +20,7 @@ export default function Chat({ role, message }) {
         <div className="flex flex-col gap-1">
           <span className="text-detail-01-regular leading-[100%] ">아끼미</span>
           <div className="bg-white py-2 px-3 rounded-2xl rounded-bl-[4px] ">
-            <span className="text-body-02-regular text-gray-100 ">{message}</span>
+            <span className="text-body-02-regular text-gray-100 whitespace-pre-wrap">{message}</span>
           </div>
         </div>
       </div>

--- a/src/hooks/chat/useChat.js
+++ b/src/hooks/chat/useChat.js
@@ -1,0 +1,69 @@
+// Chat hooks: SSE 스트림과 히스토리 조회를 위한 재사용 훅
+// - useChatStream: 메시지 ID 기반 SSE 수신
+// - useChatHistory: 페이지네이션 기반 히스토리 조회
+
+import { getChatHistoryApi, postChatApi } from "../../apis/chatApis";
+import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+// 단건 조회형 히스토리 훅 (React Query)
+export function useChatHistoryQuery({ limit = 20, beforeId = null } = {}, options = {}) {
+  return useQuery({
+    queryKey: ["chatHistory", { limit, beforeId }],
+    queryFn: () => getChatHistoryApi(limit, beforeId),
+    staleTime: 30_000,
+    refetchOnWindowFocus: false,
+    select: (data) => ({
+      items: Array.isArray(data?.messages) ? data.messages.slice().reverse() : [],
+      hasMore: Boolean(data?.hasMore),
+      nextBeforeId: data?.nextBeforeId ?? null,
+    }),
+    ...options,
+  });
+}
+
+/**
+ * useChatHistoryInfiniteQuery
+ * - React Query 기반 무한 스크롤 히스토리 조회 훅
+ * - getNextPageParam: 마지막 페이지의 마지막 아이템 id를 beforeId로 사용
+ */
+export function useChatHistoryInfiniteQuery({ pageSize = 20 } = {}) {
+  return useInfiniteQuery({
+    queryKey: ["chatHistory", pageSize],
+    initialPageParam: null,
+    queryFn: async ({ pageParam }) => {
+      return await getChatHistoryApi(pageSize, pageParam);
+    },
+    getNextPageParam: (lastPage) => {
+      return lastPage?.hasMore ? lastPage?.nextBeforeId : undefined;
+    },
+    select: (data) => {
+      const allDesc = data.pages.flatMap((p) => Array.isArray(p?.messages) ? p.messages : []);
+      const items = allDesc.slice().reverse();
+      const last = data.pages[data.pages.length - 1];
+      const hasMore = Boolean(last?.hasMore);
+      const nextBeforeId = last?.nextBeforeId ?? null;
+      return { items, hasMore, nextBeforeId, pageParams: data.pageParams };
+    },
+    refetchOnWindowFocus: false,
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * useSendMessageMutation
+ * - 메시지 전송 뮤테이션. 성공 시 히스토리 캐시 무효화
+ */
+export function useSendMessageMutation(options = {}) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationKey: ["chatSend"],
+    mutationFn: async (payload) => postChatApi(payload),
+    onSuccess: async (...args) => {
+      // 히스토리 갱신
+      await qc.invalidateQueries({ queryKey: ["chatHistory"] });
+      options.onSuccess && options.onSuccess(...args);
+    },
+    onError: options.onError,
+    onSettled: options.onSettled,
+  });
+}

--- a/src/hooks/chat/useChat.js
+++ b/src/hooks/chat/useChat.js
@@ -3,7 +3,7 @@
 // - useChatHistory: 페이지네이션 기반 히스토리 조회
 
 import { getChatHistoryApi, postChatApi } from "../../apis/chatApis";
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query";
 
 // 단건 조회형 히스토리 훅 (React Query)
 export function useChatHistoryQuery({ limit = 20, beforeId = null } = {}, options = {}) {
@@ -51,16 +51,13 @@ export function useChatHistoryInfiniteQuery({ pageSize = 20 } = {}) {
 
 /**
  * useSendMessageMutation
- * - 메시지 전송 뮤테이션. 성공 시 히스토리 캐시 무효화
+ * - 메시지 전송 뮤테이션. 성공 시 히스토리 캐시 무효 하지 않고 스트리밍 중에는 invalidate 지연 후 캐시 무효화
  */
 export function useSendMessageMutation(options = {}) {
-  const qc = useQueryClient();
   return useMutation({
     mutationKey: ["chatSend"],
     mutationFn: async (payload) => postChatApi(payload),
     onSuccess: async (...args) => {
-      // 히스토리 갱신
-      await qc.invalidateQueries({ queryKey: ["chatHistory"] });
       options.onSuccess && options.onSuccess(...args);
     },
     onError: options.onError,


### PR DESCRIPTION
### 구현 내용

* **SSE 연결 로직**

  * EventSource는 헤더를 붙일 수 없어 `fetch + ReadableStream` 기반 API로 대체
* **API 구현**

  * 전송 API
  * 채팅 내역 조회 API
* **전송 훅 구현**

  * 전송 시 채팅 내역 캐시 invalidate → 최신 내역 재조회
* **채팅 내역 무한 쿼리 훅 구현**

  * `hasMore`가 true일 때 계속 추가 로딩 가능
* **무한 스크롤 구현**

  * 특정 스크롤 위치 도달 시 자동으로 이전 내역 로드

